### PR TITLE
Render the default hotbar in single hotbar rendering mode.

### DIFF
--- a/src/main/java/com/rolandoislas/multihotbar/HotBarRenderer.java
+++ b/src/main/java/com/rolandoislas/multihotbar/HotBarRenderer.java
@@ -34,6 +34,9 @@ public class HotBarRenderer extends Gui {
         // Check if hotbar should render
         if (!(event.getType().equals(RenderGameOverlayEvent.ElementType.HOTBAR) && event.isCancelable()))
             return;
+	if (HotbarLogic.shouldShowDefault()) {
+	    return;
+	}
         event.setCanceled(true);
         // Render
         GlStateManager.color(1, 1, 1, 1);


### PR DESCRIPTION
Allows temporarily viewing HUD elements from mods that render bound to the hotbar event (workaround for #54.)